### PR TITLE
Switch from bcrypt to bcryptjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "bcrypt": "^1.0.2",
+    "bcryptjs": "^2.4.3",
     "env2": "^2.1.1",
     "handlebars": "^4.0.6",
     "hapi": "^16.1.1",


### PR DESCRIPTION
Travis was throwing on some of bcrypt's dependencies, so this switches to bcryptjs, which seems to work fine

Relates #5