### PR TITLE
Enable joke posting

### DIFF
--- a/src/postJoke.js
+++ b/src/postJoke.js
@@ -5,12 +5,6 @@ const postJoke = (username, joke, cb) => {
     if (err) insertJoke(err);
     insertJoke(null, res, joke, cb);
   });
-  // const query = `INSERT INTO lifters (${keys}) VALUES (${values})`;
-  // connect.query(query, (err, res) => {
-  //   if (err) cb(err);
-  //   console.log(`${dataObj.name} added to the database!`);
-  //   cb(null, res);
-  // });
 };
 
 const getUserID = (username, cb) => {
@@ -22,11 +16,11 @@ const getUserID = (username, cb) => {
 };
 
 const insertJoke = (err, userID, joke, cb) => {
+  if (err) return cb(err);
   const queryJoke = `INSERT INTO jokes (author_id, body) VALUES (${userID}, '${joke}');`;
   connect.query(queryJoke, (err, res) => {
     if (err) return cb(err);
-    console.log('working');
-    cb(null, res.rows[0]);
+    cb(null);
   })
 }
 

--- a/src/postJoke.js
+++ b/src/postJoke.js
@@ -1,0 +1,33 @@
+const connect = require('../database/db_connection');
+
+const postJoke = (username, joke, cb) => {
+  getUserID(username, (err, res) => {
+    if (err) insertJoke(err);
+    insertJoke(null, res, joke, cb);
+  });
+  // const query = `INSERT INTO lifters (${keys}) VALUES (${values})`;
+  // connect.query(query, (err, res) => {
+  //   if (err) cb(err);
+  //   console.log(`${dataObj.name} added to the database!`);
+  //   cb(null, res);
+  // });
+};
+
+const getUserID = (username, cb) => {
+  const queryUser = `SELECT users.id FROM users WHERE users.username = '${username}';`;
+  connect.query(queryUser, (err, res) => {
+    if (err) return cb(err);
+    cb(null, res.rows[0].id);
+  })
+};
+
+const insertJoke = (err, userID, joke, cb) => {
+  const queryJoke = `INSERT INTO jokes (author_id, body) VALUES (${userID}, '${joke}');`;
+  connect.query(queryJoke, (err, res) => {
+    if (err) return cb(err);
+    console.log('working');
+    cb(null, res.rows[0]);
+  })
+}
+
+module.exports = postJoke;

--- a/src/routes/post_submit.js
+++ b/src/routes/post_submit.js
@@ -1,8 +1,13 @@
+const postJoke = require('../postJoke');
+
 module.exports = {
   method: 'POST',
   path: '/post/submit',
   handler: (request, reply) => {
-    console.log(request.payload.joke);
-    return reply.view('post');
+    postJoke('Oli', request.payload.joke, (err, res) => {
+      if (err) console.log(err);
+      return reply.redirect('/');
+    })
+
   }
 }


### PR DESCRIPTION
Creates a method for posting jokes to the database. There are three functions in the module: the exported `postJoke` method, then two sub-functions. The first (`getUserID`) takes a username and gets the corresponding ID from the database. This then passes the ID to the second function, 
`insertJoke`, which puts the `user_id` and joke `body` into the `jokes` table.

The `post/submit` route now just redirects back to the homepage so you can see your new joke there :)