### PR TITLE
Remove host to see if this fixes Heroku

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -10,7 +10,7 @@ const routes = require('./routes');
 const server = new hapi.Server();
 
 server.connection({
-  host: process.env.HOST || 'localhost',
+  // host: process.env.HOST || 'localhost',
   port: process.env.PORT || 3000,
 });
 


### PR DESCRIPTION
Heroku doesn't like localhost with Hapi for some reason. It appears to work fine if we just don't set a host at all...

Relates #55